### PR TITLE
Added saving of search-query state to /videos page

### DIFF
--- a/components/VideoTable.vue
+++ b/components/VideoTable.vue
@@ -3,6 +3,7 @@
     <v-text-field
       v-model="search"
       single-line
+      @input="$emit('query-changed', $event)"
       hide-details>
       <template #label>
         &nbsp; Search titles of all {{videos.length}} videos
@@ -29,7 +30,7 @@
       </template>
       <template #item.played="{item}">
         <div class="green--text" v-if="isPlayed(item.id)">
-          <font-awesome-icon icon="check" /> 
+          <font-awesome-icon icon="check" />
         </div>
       </template>
       <template #item.pro="{item}">
@@ -100,6 +101,9 @@ import _ from 'lodash'
       }
     },
     methods: {
+      setSearchQuery(query) {
+        this.search = query
+      },
       goToVideo(item){
         if(this.customClickAction){
           this.customClickAction(item)
@@ -109,7 +113,7 @@ import _ from 'lodash'
       },
       filter(value, search, item) {
         let inName = RegExp(search, 'i').test(item.name)
-  
+
         return inName;
       },
       deleteVideo(video) {

--- a/pages/videos.vue
+++ b/pages/videos.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
-    <VideoTable :videos="publishedVideos" :headers="headers" :itemsPerPage="1000" class="hidden-xs-only" />
-    <VideoTable :videos="publishedVideos" :headers="mobileHeaders" :itemsPerPage="1000" :showExpand="false" class="hidden-sm-and-up" />
+    <VideoTable ref="desktopTable" @query-changed="handleQueryChange" :videos="publishedVideos" :headers="headers" :itemsPerPage="1000" class="hidden-xs-only" />
+    <VideoTable ref="mobileTable" @query-changed="handleQueryChange" :videos="publishedVideos" :headers="mobileHeaders" :itemsPerPage="1000" :showExpand="false" class="hidden-sm-and-up" />
   </div>
 </template>
 
@@ -31,12 +31,26 @@
     components: {
       VideoTable
     },
+    mounted() {
+      if (this.routeHasSearchQuery()) {
+        this.$refs.desktopTable.setSearchQuery(this.$route.query.q)
+        this.$refs.mobileTable.setSearchQuery(this.$route.query.q)
+      }
+    },
     computed: {
       ...mapState({
         allVideos: state => state.videos.videos
       }),
       publishedVideos(){
         return this.allVideos.filter(v => v.published_at < Date.now())
+      }
+    },
+    methods: {
+      handleQueryChange(query) {
+        this.$router.replace({path: '/videos', query: {q: query}})
+      },
+      routeHasSearchQuery() {
+        return this.$route.query.q && this.$route.query.q.length > 0
       }
     }
   }


### PR DESCRIPTION
I added emiting of "query-changed" event when user types something in the search field.
And at the /videos page added this event handler that replacing URL query with emitted search string.
After page refresh there is checking for query in mounted() hook.
<img width="644" src="https://user-images.githubusercontent.com/4090500/78702102-48819900-7932-11ea-9766-8e390de060f5.png">
