### PR TITLE
Added VS-Code theme styles to MarkdownDisplay.vue component

### DIFF
--- a/components/MarkdownDisplay.vue
+++ b/components/MarkdownDisplay.vue
@@ -1,12 +1,11 @@
 <template>
-    <div v-html="processedMarkdown"></div>
+    <div class="hljs-container" v-html="processedMarkdown"></div>
 </template>
 
 <script>
   import marked from 'marked';
   import highlight from 'highlight.js';
-  import 'highlight.js/styles/solarized-dark.css';
-  
+
   export default {
     computed: {
       processedMarkdown(){
@@ -16,7 +15,7 @@
               return highlight.highlightAuto(md).value
             }
           });
-        } 
+        }
       }
     },
     props: {
@@ -26,6 +25,107 @@
 </script>
 
 <style lang="scss" scoped>
+  .hljs-container ::v-deep {
+    pre {
+      display: inline-block;
+      padding: 10px;
+      background: #1e1e1e;
+      border-radius: 6px;
+      white-space: pre-wrap;
+    }
+    .hljs, code {
+      display: block;
+      overflow-x:auto;
+      padding:.5em;
+      background:#1e1e1e;
+      color:#dcdcdc;
+      font-size: 18px;
+      font-weight: 500;
+    }
+    .hljs-keyword,
+    .hljs-link,
+    .hljs-literal,
+    .hljs-name,
+    .hljs-symbol {
+      color:#569cd6;
+    }
+    .hljs-link {
+      text-decoration:underline
+    }
+    .hljs-built_in,
+    .hljs-type {
+      color:#4ec9b0
+    }
+    .hljs-class,
+    .hljs-number {
+      color:#b8d7a3
+    }
+    .hljs-meta-string,
+    .hljs-string {
+      color:#d69d85
+    }
+    .hljs-regexp,
+    .hljs-template-tag {
+      color:#9a5334
+    }
+    .hljs-formula,
+    .hljs-function,
+    .hljs-params,
+    .hljs-subst,
+    .hljs-title {
+      color:#dcdcdc
+    }
+    .hljs-comment,
+    .hljs-quote {
+      color:#57a64a;
+      font-style:italic
+    }
+    .hljs-doctag {
+      color:#608b4e
+    }
+    .hljs-meta,
+    .hljs-meta-keyword,
+    .hljs-tag {
+      color:#9b9b9b;
+    }
+    .hljs-template-variable,
+    .hljs-variable {
+      color:#bd63c5
+    }
+    .hljs-attr,
+    .hljs-attribute,
+    .hljs-builtin-name {
+      color:#9cdcfe
+    }
+    .hljs-section {
+      color:gold
+    }
+    .hljs-emphasis {
+      font-style:italic
+    }
+    .hljs-strong {
+      font-weight:700
+    }
+    .hljs-bullet,
+    .hljs-selector-attr,
+    .hljs-selector-class,
+    .hljs-selector-id,
+    .hljs-selector-pseudo,
+    .hljs-selector-tag {
+      color:#d7ba7d
+    }
+    .hljs-addition {
+      background-color:#144212
+    }
+    .hljs-addition,
+    .hljs-deletion {
+      display:inline-block;
+      width:100%
+    }
+    .hljs-deletion {
+      background-color:#600
+    }
+  }
   ::v-deep code:before {
     content: "" !important;
   }


### PR DESCRIPTION
<img width="986" alt="syntax highlight" src="https://user-images.githubusercontent.com/4090500/79494290-f38a0500-804c-11ea-8cdc-2a936303e6b4.png">
